### PR TITLE
feat: remove extra indexes and other dash flags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,7 @@ Generates (or regenerates) a requirements.txt file
 
 id: `pipenv-generate-requirements-no-index`
 
-Generates (or regenerates) a requirements.txt file without an index, useful if using a pypi mirror locally
+Generates (or regenerates) a requirements.txt file without
+* index lines (`-i`), useful if using a pypi mirror locally
+* extra index lines (`--extra-index`), useful if using multiple pypi indexes
+* other pip dash directives, like editable (`-e`)

--- a/generate-reqs-no-index.sh
+++ b/generate-reqs-no-index.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 pipenv lock -r > requirements.txt
-sed -i '' -e '/^-i/d' requirements.txt
+sed -i -e '/^-/d' requirements.txt


### PR DESCRIPTION
I was looking at using `pipenv-generate-requirements-no-index` to generate a `requirements.txt` that can then be passed on to `setuptools` as dependencies when building a package.

Dependencies in `setuptools` are expected to be [PEP 508](https://peps.python.org/pep-0508/) compatible. `setuptools` has errors with `-i`, `--extra-index-url`, or editable installs via `-e` on lines in a `requirements.txt`, used via dynamic dependencies in a `setup.cfg` or `pyproject.toml`.

A `pipenv lock -r` (now `pipenv requirements`, see #3) can generate output with these dashes, an example of which is included below.

This pull request addresses this additional use case by modifying the `sed` regex to remove all lines starting with a dash.


##### `Pipfile`
```
[[source]]
url = "https://pypi.org/simple"
verify_ssl = true
name = "pypi"

[[source]]
url = "${PIP_EXTRA_INDEX_URL}"
verify_ssl = true
name = "private"

[packages]
some-package {editable = true, git = "ssh://git@github.com/example-org/some-package.git"}
some-addon = { version = "<9.0.0,>=8.0.0", index = "private" }
```
##### `requirements.txt`
```
-i https://pypi.org/simple
--extra-index-url ${PIP_EXTRA_INDEX_URL}
some-addon=">=8.0.0,<9.0.0"
-e git+ssh://git@github.com/example-org/some-package.git@somehash#egg=some-package
(some-packages's dependencies would also appear here)
```